### PR TITLE
Update Prettier to respect EditorConfig indentation rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,6 @@
     "printWidth": 100,
     "semi": true,
     "singleQuote": true,
-    "tabWidth": 4,
     "tailwindStylesheet": "./src/styles/main.css",
     "trailingComma": "all",
     "twigAlwaysBreakObjects": false,
@@ -16,6 +15,5 @@
         "ifchildren,endifchildren",
         "cache,endcache",
         "tag,endtag"
-    ],
-    "useTabs": false
+    ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,28 +1,28 @@
 {
-	"plugins": ["@zackad/prettier-plugin-twig", "prettier-plugin-tailwindcss"],
-	"useTabs": true,
-	"tabWidth": 4,
-	"bracketSpacing": true,
-	"printWidth": 100,
-	"semi": true,
-	"singleQuote": true,
-	"tailwindStylesheet": "./src/styles/main.css",
-	"trailingComma": "all",
-	"twigAlwaysBreakObjects": false,
-	"twigSingleQuote": false,
-	"twigMultiTags": [
-		"nav,endnav",
-		"switch,case,default,endswitch",
-		"ifchildren,endifchildren",
-		"cache,endcache",
-		"tag,endtag"
-	],
-	"overrides": [
-		{
-			"files": ["*.yaml", "*.yml"],
-			"options": {
-				"tabWidth": 2
-			}
-		}
-	]
+    "plugins": ["@zackad/prettier-plugin-twig", "prettier-plugin-tailwindcss"],
+    "useTabs": false,
+    "tabWidth": 4,
+    "bracketSpacing": true,
+    "printWidth": 100,
+    "semi": true,
+    "singleQuote": true,
+    "tailwindStylesheet": "./src/styles/main.css",
+    "trailingComma": "all",
+    "twigAlwaysBreakObjects": false,
+    "twigSingleQuote": false,
+    "twigMultiTags": [
+        "nav,endnav",
+        "switch,case,default,endswitch",
+        "ifchildren,endifchildren",
+        "cache,endcache",
+        "tag,endtag"
+    ],
+    "overrides": [
+        {
+            "files": ["*.yaml", "*.yml"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,19 +1,28 @@
 {
-    "plugins": ["@zackad/prettier-plugin-twig", "prettier-plugin-tailwindcss"],
-
-    "bracketSpacing": true,
-    "printWidth": 100,
-    "semi": true,
-    "singleQuote": true,
-    "tailwindStylesheet": "./src/styles/main.css",
-    "trailingComma": "all",
-    "twigAlwaysBreakObjects": false,
-    "twigSingleQuote": false,
-    "twigMultiTags": [
-        "nav,endnav",
-        "switch,case,default,endswitch",
-        "ifchildren,endifchildren",
-        "cache,endcache",
-        "tag,endtag"
-    ]
+	"plugins": ["@zackad/prettier-plugin-twig", "prettier-plugin-tailwindcss"],
+	"useTabs": true,
+	"tabWidth": 4,
+	"bracketSpacing": true,
+	"printWidth": 100,
+	"semi": true,
+	"singleQuote": true,
+	"tailwindStylesheet": "./src/styles/main.css",
+	"trailingComma": "all",
+	"twigAlwaysBreakObjects": false,
+	"twigSingleQuote": false,
+	"twigMultiTags": [
+		"nav,endnav",
+		"switch,case,default,endswitch",
+		"ifchildren,endifchildren",
+		"cache,endcache",
+		"tag,endtag"
+	],
+	"overrides": [
+		{
+			"files": ["*.yaml", "*.yml"],
+			"options": {
+				"tabWidth": 2
+			}
+		}
+	]
 }


### PR DESCRIPTION
Different files can have different preferences or recommendations for indentation style and size.

For example, it's best to use [2-space tabs in YAML files](https://www.yaml.info/learn/bestpractices.html).