### PR TITLE
Replace mcaskill/html-build-attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "craftcms/ckeditor": "^4.8.0",
         "craftcms/cms": "^5.0.0",
         "ether/seo": "^5.0",
-        "mcaskill/php-html-build-attributes": "^1.3",
         "mmikkel/cp-clearcache": "^2.0",
         "nystudio107/craft-vite": "^5.0",
         "vlucas/phpdotenv": "^5.4.0"

--- a/templates/partial/accordion.twig
+++ b/templates/partial/accordion.twig
@@ -14,7 +14,7 @@
 
 {# ---------------------------------------- #}
 
-<c-accordion {{ html_attributes(_el_attrs) }}>
+<c-accordion {{ attr(_el_attrs) }}>
     <details class="c-accordion_details">
         <summary class="c-accordion_summary">
             <span class="c-accordion_label || c-heading -h3">{{ _title }}</span>

--- a/templates/snippet/icon.twig
+++ b/templates/snippet/icon.twig
@@ -17,7 +17,7 @@
 {# ---------------------------------------- #}
 
 {% if _icon %}
-    <span {{ html_attributes(_icon_attrs) }}>
+    <span {{ attr(_icon_attrs) }}>
         {% if _arialabel %}
             <span class="sr-only">{{ _arialabel }}</span>
         {% endif %}

--- a/templates/snippet/image.twig
+++ b/templates/snippet/image.twig
@@ -69,7 +69,7 @@
 {% if _src %}
     {% tag _tag with _container_attrs %}
         <div class="c-image_inner">
-            <img {{ html_attributes(_img_attrs) }} />
+            <img {{ attr(_img_attrs) }} />
         </div>
 
         {% if _caption %}


### PR DESCRIPTION
Resolves #4

Requires testing in a project before merging.

Replaced with equivalent helpers in CraftCMS.

Changed:
- Replaced `{{ html_attributes }}` with Craft's `{{ attr }}`.
- Replaced `{{ html_class }}` with new Twig function `{{ classAttr }}` that uses Craft's `Html::renderTagAttributes()` to render `class` attribute. Function renamed to match Craft's existing nomenclature.
- Updated `mergeTokens()` used by `classAttr` to better split tokens and ensure tokens are unique.

Documentation:
- https://craftcms.com/docs/5.x/reference/twig/functions.html#attr